### PR TITLE
Add link to Rust track on exercism.io

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,6 +110,7 @@ href="https://github.com/manishearth/rust-clippy">Clippy</a> format lints</li>
       <ul>
         <li>Carol's <a href="https://github.com/carols10cents/rustlings">Rustlings</a> -- Small problems and solutions</li>
         <li><a href="http://rosettacode.org/wiki/Category:Rust">Rosetta Code</a></li>
+        <li><a href="http://exercism.io/languages/rust">Exercism - achievable mini-quests</a></li>
         <li><a href="https://www.rust-lang.org/en-US/friends.html">Organizations</a> who use Rust in production</li>
       </ul>
       </div>


### PR DESCRIPTION
Not sure if you'll find this relevant or not but I found the exercism.io model of providing a readme + a number of tests that guide in implementing solutions using Rust was quite a useful learning tool.
